### PR TITLE
Some bug fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -6,12 +6,12 @@ all: jikespg
 jikespg: ctabs.o globals.o lpgparse.o lpgutil.o main.o \
      mkfirst.o mkred.o mkstates.o partset.o prntstat.o produce.o \
      ptables.o remsp.o resolve.o spacetab.o tabutil.o timetab.o
-	$(CC) -s -o jikespg ctabs.o globals.o lpgparse.o lpgutil.o main.o \
+	$(CC) -o jikespg ctabs.o globals.o lpgparse.o lpgutil.o main.o \
 	    mkfirst.o mkred.o mkstates.o partset.o prntstat.o produce.o \
 	    ptables.o remsp.o resolve.o spacetab.o tabutil.o timetab.o
 
 lpgact.i: jikespg.g
-	  lpg jikespg
+	  jikespg jikespg
 	  rm jikespg.l
 	  make
 	  rm CRASH_THE_INITIAL_MAKE_COMMAND_TO_BREAK_OUT
@@ -69,21 +69,21 @@ ctabs.o: ctabs.c common.h space.h
 	$(CC) -c ctabs.c
 
 clean:
-	rm jikespg
-	rm ctabs.o 
-	rm globals.o
-	rm lpgparse.o 
-	rm lpgutil.o 
-	rm main.o 
-	rm mkfirst.o 
-	rm mkred.o
-	rm mkstates.o 
-	rm partset.o 
-	rm prntstat.o 
-	rm produce.o 
-	rm ptables.o 
-	rm remsp.o
-	rm resolve.o
-	rm spacetab.o 
-	rm tabutil.o
-	rm timetab.o
+	rm -f jikespg
+	rm -f ctabs.o 
+	rm -f globals.o
+	rm -f lpgparse.o 
+	rm -f lpgutil.o 
+	rm -f main.o 
+	rm -f mkfirst.o 
+	rm -f mkred.o
+	rm -f mkstates.o 
+	rm -f partset.o 
+	rm -f prntstat.o 
+	rm -f produce.o 
+	rm -f ptables.o 
+	rm -f remsp.o
+	rm -f resolve.o
+	rm -f spacetab.o 
+	rm -f tabutil.o
+	rm -f timetab.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,12 @@
 # Makefile for aix for Jikes Parser Generator
-CC = gcc -O1
+CC = gcc $(CPPFLAGS) $(CFLAGS)
 
 all: jikespg
 
 jikespg: ctabs.o globals.o lpgparse.o lpgutil.o main.o \
      mkfirst.o mkred.o mkstates.o partset.o prntstat.o produce.o \
      ptables.o remsp.o resolve.o spacetab.o tabutil.o timetab.o
-	$(CC) -o jikespg ctabs.o globals.o lpgparse.o lpgutil.o main.o \
+	$(CC) $(LDFLAGS) -o jikespg ctabs.o globals.o lpgparse.o lpgutil.o main.o \
 	    mkfirst.o mkred.o mkstates.o partset.o prntstat.o produce.o \
 	    ptables.o remsp.o resolve.o spacetab.o tabutil.o timetab.o
 

--- a/src/ctabs.c
+++ b/src/ctabs.c
@@ -1632,7 +1632,8 @@ static void print_symbols(void)
             {
                 fwrite(line, sizeof(char), PARSER_LINE_SIZE - 2, syssym);
                 fprintf(syssym, "\\\n");
-                strcpy(line, &line[PARSER_LINE_SIZE - 2]);
+                memmove(line, &line[PARSER_LINE_SIZE - 2],
+                        strlen(&line[PARSER_LINE_SIZE - 2]) + 1);
             }
         }
     }

--- a/src/lpgparse.c
+++ b/src/lpgparse.c
@@ -392,7 +392,8 @@ static void options(void)
 
     while (parm[i] != '\0')     /* Repeat until parm line is exhausted */
     {
-        strcpy(parm, parm + i);       /* Remove garbage in front */
+        /* Remove garbage in front */
+        memmove(parm, parm + i, strlen (parm + i) + 1);
 
         i = 0;
 
@@ -442,7 +443,8 @@ static void options(void)
             {                                  /* prefix?         */
                 flag = FALSE;
                 len = len-2;
-                strcpy(token, token + 2);  /* get rid of "NO" prefix */
+                /* get rid of "NO" prefix */
+                memmove(token, token + 2, strlen(token + 2) + 1);
             }
             else
                 flag = TRUE;
@@ -3401,7 +3403,8 @@ static void display_input(void)
                 strncat(line, temp, PRINT_LINE_SIZE - 12);
                 fprintf(syslis, "\n%s", line);
                 ENDPAGE_CHECK;
-                strcpy(temp, temp + (PRINT_LINE_SIZE - 12));
+                memmove(temp, temp + (PRINT_LINE_SIZE - 12),
+                        sizeof(temp) - (PRINT_LINE_SIZE - 12));
                 i = PRINT_LINE_SIZE - 12;
                 print_large_token(line, temp, "       ", i);
             }
@@ -3429,7 +3432,8 @@ static void display_input(void)
                     strncat(line, temp, PRINT_LINE_SIZE - 12);
                     fprintf(syslis, "\n%s", line);
                     ENDPAGE_CHECK;
-                    strcpy(temp, temp + (PRINT_LINE_SIZE - 12));
+                    memmove(temp, temp + (PRINT_LINE_SIZE - 12),
+                            sizeof(temp) - (PRINT_LINE_SIZE - 12));
                     i = PRINT_LINE_SIZE - 12;
                     print_large_token(line, temp, "       ", i);
                 }

--- a/src/lpgparse.c
+++ b/src/lpgparse.c
@@ -3378,7 +3378,11 @@ static void display_input(void)
         }
         else
             strcat(line, temp);
-        strcat(line, BLANK);
+
+        if (strlen(line) < PRINT_LINE_SIZE)
+        {
+            strcat(line, BLANK);
+        }
     }
     fprintf(syslis, "\n%s", line);
     ENDPAGE_CHECK;


### PR DESCRIPTION
`jikespg` crashes on my MacBook because the macOS `strcpy` implementation aborts if the arguments overlap. Indeed, the `strcpy` spec states that overlapping arguments yield undefined behavior. This bug has already been fixed downstream in the [Ubuntu package](https://launchpad.net/ubuntu/+source/jikespg/1.3-2), so I propose that you simply adopt the Ubuntu patches to avoid divergence. These also make a few other improvements.